### PR TITLE
[iOS/Runtime] Improve game exit and critical-section recovery

### DIFF
--- a/src/xenia/app/xenia_main_ios.mm
+++ b/src/xenia/app/xenia_main_ios.mm
@@ -341,8 +341,7 @@ bool EmulatorAppIOS::OnInitialize() {
           }
         }
         if (should_queue_launch) {
-          XELOGI("iOS: Emulator thread is running; queued launch '{}'",
-                 game_path);
+          XELOGI("iOS: Emulator thread is running; queued launch '{}'", game_path.string());
           RequestGameStop("Queued launch");
           return;
         }
@@ -648,6 +647,24 @@ void EmulatorAppIOS::EmulatorThread(const std::filesystem::path& game_path,
                                     bool require_cpu_backend) {
   xe::threading::set_name("Emulator Thread");
   const bool launched_with_game = !game_path.empty();
+
+  struct ScopeExit {
+    std::function<void()> fn;
+    ~ScopeExit() {
+      if (fn) {
+        fn();
+      }
+    }
+  } notify_exit{[this, launched_with_game]() {
+    if (!launched_with_game) {
+      return;
+    }
+    app_context().CallInUIThread([this]() {
+      auto& ios_context = static_cast<ui::IOSWindowedAppContext&>(app_context());
+      ios_context.NotifyGameExited();
+    });
+  }};
+
   const bool need_profile_mode_transition =
       !emulator_initialized_.load(std::memory_order_acquire) ||
       (require_cpu_backend && !emulator_cpu_initialized_.load(std::memory_order_acquire));
@@ -723,23 +740,6 @@ void EmulatorAppIOS::EmulatorThread(const std::filesystem::path& game_path,
       });
     }
   }
-
-  struct ScopeExit {
-    std::function<void()> fn;
-    ~ScopeExit() {
-      if (fn) {
-        fn();
-      }
-    }
-  } notify_exit{[this, launched_with_game]() {
-    if (!launched_with_game) {
-      return;
-    }
-    app_context().CallInUIThread([this]() {
-      auto& ios_context = static_cast<ui::IOSWindowedAppContext&>(app_context());
-      ios_context.NotifyGameExited();
-    });
-  }};
 
   // Load game-specific config if available.
   if (!game_path.empty()) {

--- a/src/xenia/kernel/xboxkrnl/xboxkrnl_rtl.cc
+++ b/src/xenia/kernel/xboxkrnl/xboxkrnl_rtl.cc
@@ -548,6 +548,34 @@ struct X_RTL_CRITICAL_SECTION {
 #pragma pack(pop)
 static_assert_size(X_RTL_CRITICAL_SECTION, 28);
 
+static void RecoverCriticalSection(pointer_t<X_RTL_CRITICAL_SECTION> cs,
+                                   uint32_t current_thread,
+                                   const char* reason) {
+  const int32_t lock_count = cs->lock_count;
+  const int32_t recursion_count = cs->recursion_count;
+  const uint32_t owning_thread = cs->owning_thread;
+
+  XELOGW(
+      "Recovering critical section {}: cs=0x{:08X} owner=0x{:08X} "
+      "current=0x{:08X} lock_count={} recursion_count={}",
+      reason, cs.guest_address(), owning_thread, current_thread, lock_count,
+      recursion_count);
+
+  int32_t release_depth = recursion_count > 0 ? recursion_count : 1;
+  int32_t normalized_lock_count = lock_count - release_depth;
+  if (normalized_lock_count < -1) {
+    normalized_lock_count = -1;
+  }
+
+  cs->owning_thread = 0;
+  cs->recursion_count = 0;
+  cs->lock_count = normalized_lock_count;
+
+  if (normalized_lock_count != -1) {
+    xeKeSetEvent(reinterpret_cast<X_KEVENT*>(cs.host_address()), 1, 0);
+  }
+}
+
 void xeRtlInitializeCriticalSection(X_RTL_CRITICAL_SECTION* cs,
                                     uint32_t cs_ptr) {
   cs->header.type = 1;      // EventSynchronizationObject (auto reset)
@@ -631,7 +659,14 @@ void RtlEnterCriticalSection_entry(pointer_t<X_RTL_CRITICAL_SECTION> cs) {
                             nullptr);
   }
 
-  assert_true(cs->owning_thread == 0);
+  if (cs->owning_thread != 0) {
+    XELOGW(
+        "RtlEnterCriticalSection: stealing waited critical section "
+        "cs=0x{:08X} previous_owner=0x{:08X} current=0x{:08X} lock_count={} "
+        "recursion_count={}",
+        cs.guest_address(), uint32_t(cs->owning_thread), cur_thread,
+        int32_t(cs->lock_count), int32_t(cs->recursion_count));
+  }
   cs->owning_thread = cur_thread;
   cs->recursion_count = 1;
 }
@@ -670,13 +705,18 @@ void RtlLeaveCriticalSection_entry(pointer_t<X_RTL_CRITICAL_SECTION> cs) {
     XELOGE("Null critical section in RtlLeaveCriticalSection!");
     return;
   }
-  assert_true(cs->owning_thread == XThread::GetCurrentThread()->guest_object());
+  uint32_t current_thread = XThread::GetCurrentThread()->guest_object();
+  if (cs->owning_thread != current_thread) {
+    RecoverCriticalSection(cs, current_thread, "owner-mismatch");
+    return;
+  }
 
   // Drop recursion count - if it isn't zero we still have the lock.
-  assert_true(cs->recursion_count > 0);
+  if (cs->recursion_count <= 0) {
+    RecoverCriticalSection(cs, current_thread, "invalid-recursion");
+    return;
+  }
   if (--cs->recursion_count != 0) {
-    assert_true(cs->recursion_count >= 0);
-
     xe::atomic_dec(&cs->lock_count);
     return;
   }


### PR DESCRIPTION
## Summary
- harden the iOS runtime around game shutdown and guest critical-section edge cases
- avoid host aborts when guest critical-section state becomes stale or inconsistent

## Changes
- notify the iOS frontend earlier when a launched game exits so the launcher can recover cleanly
- add best-effort recovery for owner-mismatch and invalid-recursion cases in `RtlLeaveCriticalSection`
- relax waited critical-section takeover from a hard assert into logged recovery behavior

## Validation
- ran `./xb format` with `clang-format 19.1.7`
- branch-specific build not rerun in this worktree after the split; the combined formatted source was used for the release IPA build
